### PR TITLE
aggiornamenti

### DIFF
--- a/Kijilopo/Visible/Ricerca_processing/Readme.md
+++ b/Kijilopo/Visible/Ricerca_processing/Readme.md
@@ -118,3 +118,10 @@ void draw() {
 ## Video Tutorial 
 
 https://www.youtube.com/watch?v=WH31daSj4nc
+
+
+## public webcam
+
+https://github.com/sightmachine/SimpleCV/wiki/List-of-IP-Camera-Stream-URLs
+http://en.ipcams.ch/WebCam.aspx?nr=115&typ=real
+http://www.opentopia.com/webcam/16156?viewmode=livevideo


### PR DESCRIPTION
Professore buonasera,
Condivido con lei i miei pensieri. 
Ho fatto ricerca ed ho trovato anche questo sito (http://www.opentopia.com/) per prendere delle webcam pubbliche oltre al suo IP cam Live. 
Per quanto riguarda il sito che ho trovato io sono riuscito a collegare una webcam, ispezionando l'oggetto con firebug e copiando l'indirizzo direttamente dal codice html;
mentre mi rimane ancora misterioso sapere come ha fatto lei a prendere l'URL della webcam dal sito che lei mi ha consigliato, dato che andando sul codice sorgente non trovo l'url utile.

Io ho capito una cosa, il mio errore è stato lavorare sul contenuto concreto dell'immagine webcam sotto analisi, mi spiego. Dal momento che non ho un concepta cui mirare ma lo sto cercando attraverso i dati (le webcam) devo essere concreto e non lavorare sulle webcam delle più importanti piazze del mondo se poi nel vero non le posso utilizzare.
Nei siti individuati con Url appetibili solo alcune godono di viste"interessanti", la maggior parte sono vicoli, paesaggi e vie. Ho capito che devo utilizzare questi dati come fonte per qualcosa di altro, non per riproporre l'inquadratura della webcam rivisitata dalla openCV. 
So bene che su questo concetto ci sono e siamo su da ormai 1 mese se non più, ma solo confrontandomi ora sulle effettive webcam utilizzabili ne prendo vero possesso. 

So anche che dovrei spararmi per non averlo capito prima ma adesso  vedo di trovare la giusta strada, devo solo trovare qualcosa di utile, sentito e non fine a se stesso!

Guglielmo
​